### PR TITLE
Use JSON#parse instead of JSON#load

### DIFF
--- a/.gems
+++ b/.gems
@@ -1,3 +1,3 @@
-syro -v 2.0.0
+syro -v 2.1.2
 rack-test -v 0.6.3
 basica -v 1.0.0

--- a/.gems
+++ b/.gems
@@ -1,3 +1,4 @@
-syro -v 2.1.2
-rack-test -v 0.6.3
 basica -v 1.0.0
+cutest -v 1.2.3
+rack-test -v 0.6.3
+syro -v 2.1.2

--- a/lib/satz.rb
+++ b/lib/satz.rb
@@ -35,7 +35,7 @@ class Satz
   # objects that respond safely to those methods.
   module Serializer
     def self.load(value)
-      JSON.load(value, nil, create_additions: false)
+      JSON.parse(value, create_additions: false)
     end
 
     def self.dump(value)
@@ -73,7 +73,7 @@ class Satz
     #       res.status = 401
     #       reply(error: "Unauthorized")
     #     end
-    # 
+    #
     def auth
       basic_auth(env) { |user, pass| yield(user, pass) }
     end

--- a/test/all.rb
+++ b/test/all.rb
@@ -1,6 +1,6 @@
 A1 = Satz.define do
   get do
-    reply(read)
+    reply(nil)
   end
 
   post do


### PR DESCRIPTION
http://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html#method-i-load

> BEWARE: This method is meant to serialise data from trusted user input, like from your own database server or clients under your control, it could be dangerous to allow untrusted users to pass JSON sources into it. The default options for the parser can be changed via the ::load_default_options method.
